### PR TITLE
Update JMS format converter

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -27,10 +27,10 @@ Just run the command like below:
 ./vendor/bin/translation-converter translation:convert [input_dir] [output_dir] [format]
 
 # Convert from JMSTranslationBundle
-./vendor/bin/translation-converter translation:convert app/Resources/translations app/Resources/translations-new jms
+./vendor/bin/translation-converter translation:convert app/Resources/translations app/Resources/translations-new --format=jms
 
 # Convert from Yaml
-./vendor/bin/translation-converter translation:convert app/Resources/translations app/Resources/translations-new yml
+./vendor/bin/translation-converter translation:convert app/Resources/translations app/Resources/translations-new --format=yml
 ```
 
 ### Documentation

--- a/src/Command/ConvertCommand.php
+++ b/src/Command/ConvertCommand.php
@@ -60,7 +60,7 @@ class ConvertCommand extends Command
         }
 
         $reader = $this->getReader($format);
-        $converter = new Converter($reader, 'jms' === $format ? 'xlf' : $format);
+        $converter = new Converter($reader, 'jms' === $format ? ['xlf', 'xliff'] : $format);
         $converter->convert($input->getArgument('input_dir'), $input->getArgument('output_dir'), array_unique($locales));
     }
 

--- a/src/Service/Converter.php
+++ b/src/Service/Converter.php
@@ -38,7 +38,7 @@ class Converter
 
     /**
      * @param LoaderInterface $reader
-     * @param string          $format
+     * @param string|string[] $format
      */
     public function __construct(LoaderInterface $reader, $format)
     {
@@ -56,7 +56,11 @@ class Converter
     public function convert($inputDir, $outputDir, array $locales)
     {
         $inputDir = realpath($inputDir);
+        if (false === realpath($outputDir) && false === mkdir($outputDir)) {
+            throw new \Exception('Unable to create output directory.'.$outputDir);
+        }
         $outputDir = realpath($outputDir);
+
         $inputStorage = new FileStorage($this->writer, $this->reader, [$inputDir]);
         $outputStorage = new FileStorage($this->writer, $this->reader, [$outputDir], ['xliff_version' => '2.0']);
         foreach ($locales as $locale) {

--- a/tests/Fixtures/xliff.en.xliff
+++ b/tests/Fixtures/xliff.en.xliff
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
+    <file source-language="en" target-language="en" datatype="plaintext" original="not.available">
+        <header>
+            <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
+            <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
+        </header>
+        <body>
+            <trans-unit id="0" resname="key0">
+                <source>key0</source>
+                <target>trans0</target>
+            </trans-unit>
+            <trans-unit id="1" resname="bar" approved="yes">
+                <jms:reference-file>Tests/Translation/XliffMessageUpdaterTest.php</jms:reference-file>
+                <source>This is a bar.</source>
+                <target state="new">This is a bar.</target>
+            </trans-unit>
+            <trans-unit id="0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33" resname="key1" extradata="Meaning: baz">
+                <source>key1</source>
+                <target state="new">trans1</target>
+            </trans-unit>
+            <trans-unit id="fb2d5a853a8edd799b4084a828d7d6746210534b" resname="foo.bar.baz">
+                <source>foo.bar.baz</source>
+                <target state="new">foo.bar.baz</target>
+                <jms:reference-file>/a/b/c/foo/bar</jms:reference-file>
+                <jms:reference-file>/z/order/test</jms:reference-file>
+                <jms:reference-file>bar/baz</jms:reference-file>
+            </trans-unit>
+            <trans-unit id="fb2d5a853a8edd799b4084a828d7d6746210534b" resname="same.as.trans">
+                <source>same.as.trans</source>
+                <target state="new">same.as.trans</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/tests/Functional/Service/ConverterTest.php
+++ b/tests/Functional/Service/ConverterTest.php
@@ -45,10 +45,17 @@ class ConverterTest extends TestCase
     public function testConvertJMS()
     {
         $reader = new JmsReader();
-        $converter = new Converter($reader, 'xlf');
+        $converter = new Converter($reader, ['xlf', 'xliff']);
         $converter->convert(self::$fixturesDir, self::$outputDir, ['en']);
 
         $catalogue = (new XliffLoader())->load(self::$outputDir.'/messages.en.xlf', 'en');
+        $this->assertEquals('This is a bar.', $catalogue->get('bar'));
+        $meta = new Metadata($catalogue->getMetadata('bar'));
+        $this->assertTrue($meta->isApproved());
+        $this->assertEquals('new', $meta->getState());
+        $this->assertEquals('Tests/Translation/XliffMessageUpdaterTest.php', $meta->getSourceLocations()[0]['path']);
+
+        $catalogue = (new XliffLoader())->load(self::$outputDir.'/xliff.en.xlf', 'en');
         $this->assertEquals('This is a bar.', $catalogue->get('bar'));
         $meta = new Metadata($catalogue->getMetadata('bar'));
         $this->assertTrue($meta->isApproved());


### PR DESCRIPTION
* Allow to convert `.xliff` files (not only `.xlf`)
* Automatically create output directory if it does not exist
* fix command line example in README

Fixes #6

Fully open to discussion ;)